### PR TITLE
Create black command

### DIFF
--- a/src/pythoncritic/cli/cli.py
+++ b/src/pythoncritic/cli/cli.py
@@ -4,6 +4,7 @@ import datetime
 
 from pathlib import Path
 
+
 def run_flake8(args):
     print('run flake8..')
 
@@ -17,15 +18,16 @@ def run_flake8(args):
 def run_black(args):
     print('run black..')
     cmd = None
+    output_file_name = Path(args).stem + '_black_output.log'
 
     if args is not None:
-        cmd = f"black {args}"
+        cmd = f"black --check {args} 2> >(tee -a tmp/{output_file_name} >&2)"
     else:
         cmd = "black"
 
     os.system(cmd)
 
-def run_coverege():
+def run_coverage():
     print('initializing coverage..')
 
 
@@ -57,7 +59,7 @@ add_parser.set_defaults(func=run_black)
 
 add_parser = subparsers.add_parser('coverage', help='run coverage in your project')
 add_parser.add_argument(**arg_template)
-add_parser.set_defaults(func=run_coverege)
+add_parser.set_defaults(func=run_coverage)
 
 
 add_parser = subparsers.add_parser('pythoncritic', help='run flake8, black, and coverage')

--- a/tests/cli/test_run_black.py
+++ b/tests/cli/test_run_black.py
@@ -4,4 +4,5 @@ import pytest
 
 
 def test_run_black():
-    os.system("python src/pythoncritic/cli/cli.py black tests/sample/duplicate_code_sample.py")
+    file_path = "tests/sample/black_code_impossible_to_reformat_sample.py"
+    os.system(f"python src/pythoncritic/cli/cli.py black {file_path}")

--- a/tests/sample/black_code_impossible_to_reformat_sample.py
+++ b/tests/sample/black_code_impossible_to_reformat_sample.py
@@ -1,0 +1,7 @@
+def add(a,  b):
+    result = a    + b
+    return result
+
+def sub(a,  b)
+    result = a   - b
+    return result


### PR DESCRIPTION
Now, we can run black command via:

`python src/pythoncritic/cli/cli.py black file.py`